### PR TITLE
Build GC for nix development environment.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -17,14 +17,6 @@
 # $ cachix use crystal-ci
 # $ nix-shell --pure --arg musl true
 #
-# Known issue: musl does not work yet.
-#   .../lib/libgc.a(pthread_support.o): in function `GC_thr_init':
-#   pthread_support.c:(.text+0x1137): undefined reference to `gnu_get_libc_version'
-#   .../lib/libgc.a(mach_dep.o): in function `GC_with_callee_saves_pushed':
-#   mach_dep.c:(.text+0x35): undefined reference to `getcontext'
-#   .../lib/libgc.a(pthread_start.o): in function `GC_inner_start_routine':
-#   pthread_start.c:(.text+0x44): undefined reference to `__pthread_register_cancel'
-#   .../bin/ld: pthread_start.c:(.text+0x6b): undefined reference to `__pthread_unregister_cancel'
 
 {llvm ? 10, musl ? false}:
 
@@ -40,22 +32,17 @@ let
   genericBinary = { url, sha256 }:
     pkgs.stdenv.mkDerivation rec {
       name = "crystal-binary";
-      src = builtins.fetchurl { inherit url sha256; };
+      src = builtins.fetchTarball { inherit url sha256; };
 
-      # Extract only the compiler binary and the embedded GC
+      # Extract only the compiler binary
       buildCommand = ''
-        mkdir -p $out/bin $out/lib $out/tmp
-        tar --strip-components=1 -C $out/tmp -xf ${src}
+        mkdir -p $out/bin
 
-        # Darwin packages use embedded/bin/crystal and embedded/lib/libgc.a
-        [ -f "$out/tmp/embedded/lib/libgc.a" ] && mv $out/tmp/embedded/lib/libgc.a $out/lib/
-        [ -f "$out/tmp/embedded/bin/crystal" ] && mv $out/tmp/embedded/bin/crystal $out/bin/
+        # Darwin packages use embedded/bin/crystal
+        [ -f "${src}/embedded/bin/crystal" ] && cp ${src}/embedded/bin/crystal $out/bin/
 
-        # Linux packages use lib/crystal/bin/crystal and lib/crystal/lib/libgc.a
-        [ -f "$out/tmp/lib/crystal/lib/libgc.a" ] && mv $out/tmp/lib/crystal/lib/libgc.a $out/lib/
-        [ -f "$out/tmp/lib/crystal/bin/crystal" ] && mv $out/tmp/lib/crystal/bin/crystal $out/bin/
-
-        rm -rf $out/tmp
+        # Linux packages use lib/crystal/bin/crystal
+        [ -f "${src}/lib/crystal/bin/crystal" ] && cp ${src}/lib/crystal/bin/crystal $out/bin/
       '';
     };
 
@@ -63,12 +50,12 @@ let
   latestCrystalBinary = genericBinary ({
     x86_64-darwin = {
       url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-darwin-x86_64.tar.gz";
-      sha256 = "sha256:1dhs18riq8lyz82948f44ya1k6pp4fy7j9wkxzqsj3wha03gfxbx";
+      sha256 = "sha256:0gpn42xh372hw2bqfgxc9wibpbam8gn7gx3p1b8p9adydjg0zxfm";
     };
 
     x86_64-linux = {
       url = "https://github.com/crystal-lang/crystal/releases/download/0.35.1/crystal-0.35.1-1-linux-x86_64.tar.gz";
-      sha256 = "sha256:1ygp4gf0cl8cpa8sw974lsdrngldgkyym6ha3cq0fadkfdhd6gvc";
+      sha256 = "sha256:077pby4ylf0z831gg0hbiwxcq3g0yl0cdlybirgg8rv24a2sa7zh";
     };
 
     i686-linux = {
@@ -102,6 +89,15 @@ let
     };
   }."llvm_${toString llvm}");
 
+  boehmgc = pkgs.boehmgc.overrideAttrs (oldAttrs: rec {
+    patches = [
+      (pkgs.fetchpatch {
+        url = "https://raw.githubusercontent.com/crystal-lang/distribution-scripts/e942880dda3b100ff1143cce88b579bbec3f05b9/linux/files/feature-thread-stackbottom-upstream.patch";
+        sha256 = "784ade9fe1c2668db77a3c08cd195cd7701331bdf8c9d160038cfce099b77e37";
+      })
+    ];
+  });
+
   stdLibDeps = with pkgs; [
       gmp libevent libiconv libxml2 libyaml openssl pcre zlib
     ] ++ stdenv.lib.optionals stdenv.isDarwin [ libiconv ];
@@ -116,9 +112,9 @@ pkgs.stdenv.mkDerivation rec {
     latestCrystalBinary
     pkgconfig
     llvm_suite.llvm
+    boehmgc
   ];
 
-  CRYSTAL_LIBRARY_PATH = "${latestCrystalBinary}/lib";
   LLVM_CONFIG = "${llvm_suite.llvm}/bin/llvm-config";
 
   # ld: warning: object file (.../src/ext/libcrystal.a(sigfault.o)) was built for newer OSX version (10.14) than being linked (10.12)


### PR DESCRIPTION
Overrides the boehmgc package to apply patch needed for mt support.

Quick followup to discussion in crystal-lang/crystal#9727. A little simpler to submit changes here rather than inline on that thread. I noticed that you already have the patch in the distribution-scripts repo. This applies that, then feeds in the result for the dev environment uses.

There still looks to be an issue with llvm_ext under musl, but hopefully this pushes things in the right general direction.

Note: SHA’s have changed on the binaries too as switched them over to `fetchTarball` to keep the extracted version in the nix store as opposed to the archive.